### PR TITLE
Add async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ readme = "./README.md"
 
 [dependencies]
 embedded-hal = "1.0.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
+maybe-async-cfg = "0.2.4"
+
+[features]
+async = ["dep:embedded-hal-async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Tested on ESP32 and ADS1115
 [Documentation](https://www.ti.com/product/ADS1115)
 
 ## Example
+
+### Blocking
 ```rust
 let i2c_speed = RateExtU32::kHz(100);
 
@@ -24,6 +26,33 @@ match adc.read_single_voltage(None){
 }
 ```
 
+### Async
+
+Add feature `async` to `Cargo.toml`:
+
+```toml
+[dependencies]
+embedded-ads111x = { features = ["async"] }
+```
+
+```rust
+let mut i2c = I2c::new(p.I2C1, p.PA15, p.PB7, Irqs, p.DMA1_CH6, p.DMA1_CH5, hz(100_000), Default::default());
+
+let config = ADS111xConfig::default()
+    .mux(ads111x::InputMultiplexer::AIN0GND)
+    .dr(ads111x::DataRate::SPS8)
+    .pga(ads111x::ProgramableGainAmplifier::V4_096);
+
+let mut adc = match ADS111x::new(i2c, 0x48u8, config){
+    Err(e) => panic!("Error {:?}", e),
+    Ok(x) => x,
+};
+
+match adc.read_single_voltage(None).await {
+    Ok(v) => println!("Val single {:.6}", v),
+    Err(e) => println!("Error {:?}", e),
+}
+```
 ## License
 
 Licensed under either of:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ADS111x 16bit ADCs I2C rust driver no_std
-Tested on ESP32 and ADS1115
+Tested on ESP32, STM32G421, and ADS1115
 [Documentation](https://www.ti.com/product/ADS1115)
 
 ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,11 @@ where
         Ok(ADS111x{ i2c, address, config} )
     }
 
+    ///Destroys driver instance and returns I²C bus instance.
+    pub fn destroy(self) -> I2C {
+        self.i2c
+    }
+
     ///Writes self configuration to device
     ///Config can be used to update configuration
     pub async fn write_config(&mut self, config: Option<ADS111xConfig>) -> Result<(), E>{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use embedded_hal::blocking::i2c::{WriteRead, Write};
+use embedded_hal::i2c::{I2c};
 
 static CONVERSION_REGISTER : u8 = 0b00;
 static CONFIG_REGISTER     : u8 = 0b01;
@@ -422,9 +422,8 @@ pub struct ADS111x<I2C> {
 }
 
 impl<I2C, E> ADS111x<I2C>
-where 
-    I2C:WriteRead<Error = E>,
-    I2C:Write<Error = E>,
+where
+    I2C: I2c<Error = E>,
 {
     pub fn new(i2c: I2C, address: u8, config: ADS111xConfig) -> Result<Self, ADSError>{
         match address {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
+#[cfg(not(feature = "async"))]
 use embedded_hal::i2c::{I2c};
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::{I2c};
 
 static CONVERSION_REGISTER : u8 = 0b00;
 static CONFIG_REGISTER     : u8 = 0b01;
@@ -415,12 +418,22 @@ impl ADS111xConfig{
     }
 }
 
+#[maybe_async_cfg::maybe(
+    sync(cfg(not(feature = "async")),),
+    async(feature="async"),
+    keep_self
+)]
 pub struct ADS111x<I2C> {
     i2c: I2C,
     address: u8,
     config: ADS111xConfig,
 }
 
+#[maybe_async_cfg::maybe(
+    sync(cfg(not(feature = "async")),),
+    async(feature="async"),
+    keep_self
+)]
 impl<I2C, E> ADS111x<I2C>
 where
     I2C: I2c<Error = E>,
@@ -438,27 +451,27 @@ where
 
     ///Writes self configuration to device
     ///Config can be used to update configuration
-    pub fn write_config(&mut self, config: Option<ADS111xConfig>) -> Result<(), E>{
+    pub async fn write_config(&mut self, config: Option<ADS111xConfig>) -> Result<(), E>{
         if let Some(conf) = config{
             self.config = conf;
         }
         self.config.osw = OSW::Idle;
         let conf = self.config.bits().to_be_bytes();
-        self.i2c.write(self.address, &[CONFIG_REGISTER, conf[0], conf[1]])
+        self.i2c.write(self.address, &[CONFIG_REGISTER, conf[0], conf[1]]).await
     }
 
-    pub fn read_config(&mut self) -> Result<ADS111xConfig, E>{
+    pub async fn read_config(&mut self) -> Result<ADS111xConfig, E>{
         self.config.osw = OSW::Idle;
         let mut conf = [0, 0];
 
-        self.i2c.write_read(self.address, &[CONFIG_REGISTER], &mut conf).and(Ok(ADS111xConfig::from_bits(u16::from_be_bytes(conf))))
+        self.i2c.write_read(self.address, &[CONFIG_REGISTER], &mut conf).await.and(Ok(ADS111xConfig::from_bits(u16::from_be_bytes(conf))))
     }
 
     /// Perform single read when mode set to single
     /// ADC is in low power state until requested and will go back after conversion
     /// Will block until converstion is ready
     /// Mux can be used to reconfigure what ADC input to read
-    pub fn read_single_voltage(&mut self, mux: Option<InputMultiplexer>) -> Result<f32, E>{
+    pub async fn read_single_voltage(&mut self, mux: Option<InputMultiplexer>) -> Result<f32, E>{
         if let Some(m) = mux{
             self.config.mux = m;
         }
@@ -466,17 +479,17 @@ where
         let config = self.config.bits().to_be_bytes();
         let mut conf = [0, 0];
 
-        self.i2c.write_read(self.address, &[CONFIG_REGISTER, config[0], config[1]], &mut conf)?;
+        self.i2c.write_read(self.address, &[CONFIG_REGISTER, config[0], config[1]], &mut conf).await?;
 
         while OSR::from_bits(u16::from_be_bytes(conf)) == OSR::PerformingConversion{
-            self.i2c.write_read(self.address, &[CONFIG_REGISTER], &mut conf)?;
+            self.i2c.write_read(self.address, &[CONFIG_REGISTER], &mut conf).await?;
         }
 
-        self.read_voltage()
+        self.read_voltage().await
     }
 
-    pub fn check_cnversion_ready(&mut self) -> Result<bool, E>{
-        Ok(self.read_config()?.osr == OSR::DeviceIdle)
+    pub async fn check_cnversion_ready(&mut self) -> Result<bool, E>{
+        Ok(self.read_config().await?.osr == OSR::DeviceIdle)
     }
 
     /// Reads conversion
@@ -484,9 +497,9 @@ where
     /// will return 0 when conversion was still ongoing
     /// You can use check_coversion_ready if needed
     /// only works when Mode is Continuous
-    pub fn read_voltage(&mut self) -> Result<f32, E> {
+    pub async fn read_voltage(&mut self) -> Result<f32, E> {
         let mut voltage = [0, 0];
-        self.i2c.write_read(self.address, &[CONVERSION_REGISTER], &mut voltage)?;
+        self.i2c.write_read(self.address, &[CONVERSION_REGISTER], &mut voltage).await?;
         let val = i16::from_be_bytes(voltage);
         let pga = match self.config.pga{
             ProgramableGainAmplifier::V0_256 => 0.256f32,
@@ -500,13 +513,13 @@ where
         Ok(f32::from(val) * pga / 32768f32)
     }
 
-    pub fn set_low_treshold(&mut self, low_tresh: i16) -> Result<(), E>{
+    pub async fn set_low_treshold(&mut self, low_tresh: i16) -> Result<(), E>{
         let lt = low_tresh.to_be_bytes();
-        self.i2c.write(self.address, &[LO_THRESH_REGISTER, lt[0], lt[1]])
+        self.i2c.write(self.address, &[LO_THRESH_REGISTER, lt[0], lt[1]]).await
     }
 
-    pub fn set_high_treshold(&mut self, high_tresh: i16) -> Result<(), E>{
+    pub async fn set_high_treshold(&mut self, high_tresh: i16) -> Result<(), E>{
         let ht = high_tresh.to_be_bytes();
-        self.i2c.write(self.address, &[HI_THRESH_REGISTER, ht[0], ht[1]])
+        self.i2c.write(self.address, &[HI_THRESH_REGISTER, ht[0], ht[1]]).await
     }
 }


### PR DESCRIPTION
This will add async support to the library. The async support is optional and is activated by setting the feature flag `async`.

The old (blocking) API should still be intact if the feature is not activated.